### PR TITLE
Handle the priority field correctly when a value is explicitly set

### DIFF
--- a/json_metadata.go
+++ b/json_metadata.go
@@ -8,7 +8,7 @@ type keyslot struct {
 	Af       antiForensic `json:"af"`
 	Area     area         `json:"area"`
 	Kdf      kdf          `json:"kdf"`
-	Priority string       `json:"priority"` // it is actually a number, but we need to distinguish '0' (ignore), from absence of the field (normal priority)
+	Priority *int         `json:"priority"` // need to distinguish 0 (ignore) from absence of the field (normal priority)
 }
 
 type antiForensic struct {

--- a/luks2.go
+++ b/luks2.go
@@ -117,9 +117,9 @@ func (d *deviceV2) Path() string {
 func (d *deviceV2) Slots() []int {
 	var normPrio, highPrio []int
 	for i, k := range d.meta.Keyslots {
-		if k.Priority == "2" {
+		if k.Priority != nil && *k.Priority == 2 {
 			highPrio = append(highPrio, i)
-		} else {
+		} else if k.Priority == nil || *k.Priority == 1 {
 			normPrio = append(normPrio, i)
 		}
 	}


### PR DESCRIPTION
I encountered the error
`json: cannot unmarshal number into Go struct field keyslot.keyslots.priority of type string`
when trying to unlock a volume that had had one of its keyslots boosted in priority with
`cryptsetup config --priority prefer --key-slot 1 /dev/sda3`.

This commit resolves it by using a pointer field to expose presence information.