### PR TITLE
luks2: Take digest length to be compared from expected digest

### DIFF
--- a/luks2.go
+++ b/luks2.go
@@ -243,7 +243,7 @@ func (d *deviceV2) UnsealVolume(keyslotIdx int, passphrase []byte) (*Volume, err
 	if err != nil {
 		return nil, fmt.Errorf("keyslotIdx[%v].digest.Digest base64 parsing failed: %v", keyslotIdx, err)
 	}
-	if !bytes.Equal(generatedDigest, expectedDigest) {
+	if !bytes.Equal(generatedDigest[0:len(expectedDigest)], expectedDigest) {
 		return nil, ErrPassphraseDoesNotMatch
 	}
 	clearSlice(generatedDigest)


### PR DESCRIPTION
LUKS1 was limited to a 20 byte digest length. With LUKS2 this limitation was lifted. However, it seems that for LUKS volumes which were converted from LUKS1 to LUKS2, the digest length it still 20 bytes. This commit proposes using the length of the expected digest to determine the digit length in use. For this purpose, it only compares the first n bytes of the generated digest with the expected digest.

This fixes compatibility of luks.go with volumes converted from LUKS1.

Fixes: #11

See also: https://github.com/anatol/booster/issues/202

---

Note that I only briefly skimmed over the LUKS format specification, hence I am no expert and don't know if there is a better way to obtain the desired digest length. I did, however, confirm that this does fix opening converted LUKS2 volumes.