### PR TITLE
Add OpenWithHeader for detached LUKS header support

### DIFF
--- a/luks.go
+++ b/luks.go
@@ -67,6 +67,28 @@ type Token struct {
 	Payload []byte
 }
 
+// openFromFiles detects the LUKS version from hdrF, verifies the magic bytes,
+// and dispatches to the appropriate init function.
+func openFromFiles(devicePath string, hdrF, dataF *os.File) (Device, error) {
+	// LUKS magic and version are stored in the first 8 bytes of the LUKS header
+	header := make([]byte, 8)
+	if _, err := hdrF.ReadAt(header, 0); err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(header[0:6], []byte("LUKS\xba\xbe")) {
+		return nil, fmt.Errorf("invalid LUKS header")
+	}
+	version := int(header[6])<<8 + int(header[7])
+	switch version {
+	case 1:
+		return initV1Device(devicePath, hdrF, dataF)
+	case 2:
+		return initV2Device(devicePath, hdrF, dataF)
+	default:
+		return nil, fmt.Errorf("invalid LUKS version %v", version)
+	}
+}
+
 // Open reads LUKS headers from the given partition and returns LUKS device object.
 // This function internally handles LUKS v1 and v2 partitions metadata.
 func Open(path string) (Device, error) {
@@ -74,27 +96,11 @@ func Open(path string) (Device, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// LUKS Magic and version are stored in the first 8 bytes of the LUKS header
-	header := make([]byte, 8)
-	if _, err := f.ReadAt(header[:], 0); err != nil {
-		return nil, err
+	dev, err := openFromFiles(path, f, f)
+	if err != nil {
+		f.Close()
 	}
-
-	// verify header magic
-	if !bytes.Equal(header[0:6], []byte("LUKS\xba\xbe")) {
-		return nil, fmt.Errorf("invalid LUKS header")
-	}
-
-	version := int(header[6])<<8 + int(header[7])
-	switch version {
-	case 1:
-		return initV1Device(path, f, f)
-	case 2:
-		return initV2Device(path, f, f)
-	default:
-		return nil, fmt.Errorf("invalid LUKS version %v", version)
-	}
+	return dev, err
 }
 
 // OpenWithHeader opens a LUKS device that uses a detached header.
@@ -105,41 +111,15 @@ func OpenWithHeader(devicePath, headerPath string) (Device, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	header := make([]byte, 8)
-	if _, err := hdrF.ReadAt(header, 0); err != nil {
-		hdrF.Close()
-		return nil, err
-	}
-
-	if !bytes.Equal(header[0:6], []byte("LUKS\xba\xbe")) {
-		hdrF.Close()
-		return nil, fmt.Errorf("invalid LUKS header")
-	}
-
-	version := int(header[6])<<8 + int(header[7])
-
 	dataF, err := os.Open(devicePath)
 	if err != nil {
 		hdrF.Close()
 		return nil, err
 	}
-
-	var dev Device
-	defer func() {
-		if dev == nil {
-			hdrF.Close()
-			dataF.Close()
-		}
-	}()
-
-	switch version {
-	case 1:
-		dev, err = initV1Device(devicePath, hdrF, dataF)
-	case 2:
-		dev, err = initV2Device(devicePath, hdrF, dataF)
-	default:
-		err = fmt.Errorf("invalid LUKS version %v", version)
+	dev, err := openFromFiles(devicePath, hdrF, dataF)
+	if err != nil {
+		hdrF.Close()
+		dataF.Close()
 	}
 	return dev, err
 }

--- a/luks.go
+++ b/luks.go
@@ -89,12 +89,59 @@ func Open(path string) (Device, error) {
 	version := int(header[6])<<8 + int(header[7])
 	switch version {
 	case 1:
-		return initV1Device(path, f)
+		return initV1Device(path, f, f)
 	case 2:
-		return initV2Device(path, f)
+		return initV2Device(path, f, f)
 	default:
 		return nil, fmt.Errorf("invalid LUKS version %v", version)
 	}
+}
+
+// OpenWithHeader opens a LUKS device that uses a detached header.
+// The LUKS metadata and keyslot material are read from headerPath,
+// while the encrypted data resides on devicePath.
+func OpenWithHeader(devicePath, headerPath string) (Device, error) {
+	hdrF, err := os.Open(headerPath)
+	if err != nil {
+		return nil, err
+	}
+
+	header := make([]byte, 8)
+	if _, err := hdrF.ReadAt(header, 0); err != nil {
+		hdrF.Close()
+		return nil, err
+	}
+
+	if !bytes.Equal(header[0:6], []byte("LUKS\xba\xbe")) {
+		hdrF.Close()
+		return nil, fmt.Errorf("invalid LUKS header")
+	}
+
+	version := int(header[6])<<8 + int(header[7])
+
+	dataF, err := os.Open(devicePath)
+	if err != nil {
+		hdrF.Close()
+		return nil, err
+	}
+
+	var dev Device
+	defer func() {
+		if dev == nil {
+			hdrF.Close()
+			dataF.Close()
+		}
+	}()
+
+	switch version {
+	case 1:
+		dev, err = initV1Device(devicePath, hdrF, dataF)
+	case 2:
+		dev, err = initV2Device(devicePath, hdrF, dataF)
+	default:
+		err = fmt.Errorf("invalid LUKS version %v", version)
+	}
+	return dev, err
 }
 
 // Lock closes device mapper partition with the given name

--- a/luks1.go
+++ b/luks1.go
@@ -43,26 +43,33 @@ const luksV1SlotEnabled = 0xAC71F3
 
 type deviceV1 struct {
 	path  string
-	f     *os.File
+	hdrF  *os.File // header file: source of keyslot material
+	dataF *os.File // data device: used for storage size; equals hdrF when header is embedded
 	hdr   *headerV1
 	flags []string
 }
 
-func initV1Device(path string, f *os.File) (*deviceV1, error) {
+func initV1Device(path string, hdrF, dataF *os.File) (*deviceV1, error) {
 	var hdr headerV1
 
-	if _, err := f.Seek(0, 0); err != nil {
+	if _, err := hdrF.Seek(0, 0); err != nil {
 		return nil, err
 	}
-	if err := binary.Read(f, binary.BigEndian, &hdr); err != nil {
+	if err := binary.Read(hdrF, binary.BigEndian, &hdr); err != nil {
 		return nil, err
 	}
 
-	return &deviceV1{path: path, f: f, hdr: &hdr}, nil
+	return &deviceV1{path: path, hdrF: hdrF, dataF: dataF, hdr: &hdr}, nil
 }
 
 func (d *deviceV1) Close() error {
-	return d.f.Close()
+	err := d.hdrF.Close()
+	if d.dataF != d.hdrF {
+		if err2 := d.dataF.Close(); err == nil {
+			err = err2
+		}
+	}
+	return err
 }
 
 func (d *deviceV1) Path() string {
@@ -164,7 +171,7 @@ func (d *deviceV1) UnsealVolume(keyslotIdx int, passphrase []byte) (*Volume, err
 
 	storageOffset := uint64(d.hdr.PayloadOffset) * storageSectorSize
 
-	storageSize, err := fileSize(d.f)
+	storageSize, err := fileSize(d.dataF)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +205,7 @@ func (d *deviceV1) decryptLuks1VolumeKey(keyslotIdx int, slot keySlot, afKey []b
 	keyData := make([]byte, keyslotSize)
 	defer clearSlice(keyData)
 
-	if _, err := d.f.ReadAt(keyData, int64(slot.KeyMaterialOffset)*storageSectorSize); err != nil {
+	if _, err := d.hdrF.ReadAt(keyData, int64(slot.KeyMaterialOffset)*storageSectorSize); err != nil {
 		return nil, err
 	}
 
@@ -273,7 +280,7 @@ func (d *deviceV1) Tokens() ([]Token, error) {
 	}
 	holeOffset = roundUp(holeOffset, 4096)
 
-	if _, err := d.f.ReadAt(data, int64(holeOffset)); err != nil {
+	if _, err := d.hdrF.ReadAt(data, int64(holeOffset)); err != nil {
 		return nil, err
 	}
 	if err := binary.Read(bytes.NewReader(data), binary.BigEndian, &hdr); err != nil {
@@ -298,7 +305,7 @@ func (d *deviceV1) Tokens() ([]Token, error) {
 	for i, s := range hdr.Slots {
 		if !bytes.Equal(s.UUID[:], luksMetaNullUUID) {
 			payload := make([]byte, s.Length)
-			if _, err := d.f.ReadAt(payload, int64(holeOffset)+int64(s.Offset)); err != nil {
+			if _, err := d.hdrF.ReadAt(payload, int64(holeOffset)+int64(s.Offset)); err != nil {
 				return nil, err
 			}
 			tokenChecksum := crc32.New(crc32.MakeTable(crc32.Castagnoli))

--- a/luks1_test.go
+++ b/luks1_test.go
@@ -36,7 +36,7 @@ func runLuks1Test(t *testing.T, cryptsetupArgs ...string) {
 	defer disk.Close()
 	defer os.Remove(disk.Name())
 
-	d, err := initV1Device(disk.Name(), disk)
+	d, err := initV1Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 
 	tokens, err := d.Tokens()
@@ -82,7 +82,7 @@ func TestLuks1UnlockMultipleKeySlots(t *testing.T) {
 	}
 	require.NoError(t, addKeyCmd.Run())
 
-	d, err := initV1Device(disk.Name(), disk)
+	d, err := initV1Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 
 	tokens, err := d.Tokens()
@@ -94,6 +94,97 @@ func TestLuks1UnlockMultipleKeySlots(t *testing.T) {
 
 	_, err = d.UnsealVolume(1, []byte(password2))
 	require.NoError(t, err)
+}
+
+func TestLuks1DetachedHeader(t *testing.T) {
+	t.Parallel()
+
+	password := "foobar"
+
+	data, err := os.CreateTemp("", "luksv1.go.data")
+	require.NoError(t, err)
+	defer os.Remove(data.Name())
+	defer data.Close()
+	require.NoError(t, data.Truncate(2*1024*1024))
+
+	hdr, err := os.CreateTemp("", "luksv1.go.hdr")
+	require.NoError(t, err)
+	defer os.Remove(hdr.Name())
+	defer hdr.Close()
+	require.NoError(t, hdr.Truncate(2*1024*1024))
+
+	cmd := exec.Command("cryptsetup", "luksFormat", "--type", "luks1", "--iter-time", "5", "-q", "--header", hdr.Name(), data.Name())
+	cmd.Stdin = strings.NewReader(password)
+	if testing.Verbose() {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+	require.NoError(t, cmd.Run())
+
+	d, err := OpenWithHeader(data.Name(), hdr.Name())
+	require.NoError(t, err)
+	defer d.Close()
+
+	_, err = d.UnsealVolume(0, []byte(password))
+	require.NoError(t, err)
+}
+
+func TestOpenWithHeaderMissingHeaderFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := OpenWithHeader("/dev/null", "/nonexistent/header/path")
+	require.Error(t, err)
+}
+
+func TestOpenWithHeaderInvalidMagic(t *testing.T) {
+	t.Parallel()
+
+	hdr, err := os.CreateTemp("", "luks.go.badhdr")
+	require.NoError(t, err)
+	defer os.Remove(hdr.Name())
+	hdr.Close()
+
+	require.NoError(t, os.WriteFile(hdr.Name(), []byte("notluks!!"), 0600))
+
+	_, err = OpenWithHeader("/dev/null", hdr.Name())
+	require.ErrorContains(t, err, "invalid LUKS header")
+}
+
+func TestOpenWithHeaderMissingDataFile(t *testing.T) {
+	t.Parallel()
+
+	// Build a minimal fake header: LUKS magic + version 1 + zeroes
+	fakeHdr := make([]byte, 592) // headerV1 is 592 bytes
+	copy(fakeHdr, "LUKS\xba\xbe")
+	fakeHdr[6] = 0x00
+	fakeHdr[7] = 0x01
+
+	hdr, err := os.CreateTemp("", "luks.go.fakehdr")
+	require.NoError(t, err)
+	defer os.Remove(hdr.Name())
+	hdr.Close()
+
+	require.NoError(t, os.WriteFile(hdr.Name(), fakeHdr, 0600))
+
+	_, err = OpenWithHeader("/nonexistent/data/path", hdr.Name())
+	require.Error(t, err)
+}
+
+func TestOpenWithHeaderUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	// Valid magic, unsupported version 3
+	fakeHdr := []byte("LUKS\xba\xbe\x00\x03")
+
+	hdr, err := os.CreateTemp("", "luks.go.ver3hdr")
+	require.NoError(t, err)
+	defer os.Remove(hdr.Name())
+	hdr.Close()
+
+	require.NoError(t, os.WriteFile(hdr.Name(), fakeHdr, 0600))
+
+	_, err = OpenWithHeader("/dev/null", hdr.Name())
+	require.ErrorContains(t, err, "invalid LUKS version 3")
 }
 
 func TestReadLuksMetaInitialized(t *testing.T) {
@@ -131,7 +222,7 @@ func TestReadLuksMetaInitialized(t *testing.T) {
 	}
 	require.NoError(t, saveMeta2.Run())
 
-	d, err := initV1Device(disk.Name(), disk)
+	d, err := initV1Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 
 	tokens, err := d.Tokens()

--- a/luks2.go
+++ b/luks2.go
@@ -39,19 +39,20 @@ type headerV2 struct {
 
 type deviceV2 struct {
 	path  string
-	f     *os.File
+	hdrF  *os.File // header file: source of keyslot material
+	dataF *os.File // data device: used for storage size; equals hdrF when header is embedded
 	hdr   *headerV2
 	meta  *metadata
 	flags []string
 }
 
-func initV2Device(path string, f *os.File) (*deviceV2, error) {
+func initV2Device(path string, hdrF, dataF *os.File) (*deviceV2, error) {
 	var hdr headerV2
 
-	if _, err := f.Seek(0, 0); err != nil {
+	if _, err := hdrF.Seek(0, 0); err != nil {
 		return nil, err
 	}
-	if err := binary.Read(f, binary.BigEndian, &hdr); err != nil {
+	if err := binary.Read(hdrF, binary.BigEndian, &hdr); err != nil {
 		return nil, err
 	}
 
@@ -62,7 +63,7 @@ func initV2Device(path string, f *os.File) (*deviceV2, error) {
 
 	// read the whole header
 	data := make([]byte, hdrSize)
-	if _, err := f.ReadAt(data, 0); err != nil {
+	if _, err := hdrF.ReadAt(data, 0); err != nil {
 		return nil, err
 	}
 
@@ -99,7 +100,8 @@ func initV2Device(path string, f *os.File) (*deviceV2, error) {
 
 	return &deviceV2{
 		path:  path,
-		f:     f,
+		hdrF:  hdrF,
+		dataF: dataF,
 		hdr:   &hdr,
 		meta:  &meta,
 		flags: meta.Config.Flags,
@@ -107,7 +109,13 @@ func initV2Device(path string, f *os.File) (*deviceV2, error) {
 }
 
 func (d *deviceV2) Close() error {
-	return d.f.Close()
+	err := d.hdrF.Close()
+	if d.dataF != d.hdrF {
+		if err2 := d.dataF.Close(); err == nil {
+			err = err2
+		}
+	}
+	return err
 }
 
 func (d *deviceV2) Path() string {
@@ -264,7 +272,7 @@ func (d *deviceV2) UnsealVolume(keyslotIdx int, passphrase []byte) (*Volume, err
 
 	var storageSize uint64
 	if storageSegment.Size == "dynamic" {
-		storageSize, err = fileSize(d.f)
+		storageSize, err = fileSize(d.dataF)
 		if err != nil {
 			return nil, err
 		}
@@ -352,7 +360,7 @@ func (d *deviceV2) decryptLuks2VolumeKey(keyslotIdx int, keyslot keyslot, afKey 
 		return nil, fmt.Errorf("keyslot[%v] offset %v is not aligned to sector size %v", keyslotIdx, keyslotOffset, storageSectorSize)
 	}
 
-	if _, err := d.f.ReadAt(keyData, keyslotOffset); err != nil {
+	if _, err := d.hdrF.ReadAt(keyData, keyslotOffset); err != nil {
 		return nil, err
 	}
 

--- a/luks2_test.go
+++ b/luks2_test.go
@@ -45,7 +45,7 @@ func runLuks2Test(t *testing.T, keySlot int, cryptsetupArgs ...string) {
 	defer disk.Close()
 	defer os.Remove(disk.Name())
 
-	d, err := initV2Device(disk.Name(), disk)
+	d, err := initV2Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 
 	uuid, err := blkidUUID(disk.Name())
@@ -108,6 +108,39 @@ func TestLuks2WithIntegrity(t *testing.T) {
 	runLuks2Test(t, 0, "--cipher", "aes-xts-plain64", "--integrity", "hmac-sha256", "--integrity-no-wipe", "--sector-size", "4096")
 }
 
+func TestLuks2DetachedHeader(t *testing.T) {
+	t.Parallel()
+
+	password := "foobar"
+
+	data, err := os.CreateTemp("", "luksv2.go.data")
+	require.NoError(t, err)
+	defer os.Remove(data.Name())
+	defer data.Close()
+	require.NoError(t, data.Truncate(2*1024*1024))
+
+	hdr, err := os.CreateTemp("", "luksv2.go.hdr")
+	require.NoError(t, err)
+	defer os.Remove(hdr.Name())
+	defer hdr.Close()
+	require.NoError(t, hdr.Truncate(16*1024*1024))
+
+	cmd := exec.Command("cryptsetup", "luksFormat", "--type", "luks2", "--iter-time", "5", "-q", "--header", hdr.Name(), data.Name())
+	cmd.Stdin = strings.NewReader(password)
+	if testing.Verbose() {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+	require.NoError(t, cmd.Run())
+
+	d, err := OpenWithHeader(data.Name(), hdr.Name())
+	require.NoError(t, err)
+	defer d.Close()
+
+	_, err = d.UnsealVolume(0, []byte(password))
+	require.NoError(t, err)
+}
+
 func TestLuks2UnlockMultipleKeySlots(t *testing.T) {
 	t.Parallel()
 
@@ -127,7 +160,7 @@ func TestLuks2UnlockMultipleKeySlots(t *testing.T) {
 	}
 	require.NoError(t, addKeyCmd.Run())
 
-	d, err := initV2Device(disk.Name(), disk)
+	d, err := initV2Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 
 	_, err = d.UnsealVolume(0, []byte(password))
@@ -156,7 +189,7 @@ func TestLuks2UnlockWithToken(t *testing.T) {
 	}
 	require.NoError(t, addTokenCmd.Run())
 
-	d, err := initV2Device(disk.Name(), disk)
+	d, err := initV2Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 
 	slots := d.Slots()
@@ -199,7 +232,7 @@ func TestLuks2PreferedPriority(t *testing.T) {
 	}
 	require.NoError(t, configCmd.Run())
 
-	d, err := initV2Device(disk.Name(), disk)
+	d, err := initV2Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 
 	uuid, err := blkidUUID(disk.Name())

--- a/luks_conversion_test.go
+++ b/luks_conversion_test.go
@@ -37,7 +37,7 @@ func TestConvertV1toV2(t *testing.T) {
 	defer disk.Close()
 	defer os.Remove(disk.Name())
 
-	d, err := initV1Device(disk.Name(), disk)
+	d, err := initV1Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 
 	tokens, err := d.Tokens()
@@ -55,7 +55,7 @@ func TestConvertV1toV2(t *testing.T) {
 	err = exec.Command("cryptsetup", "convert", "--type", "luks2", disk.Name()).Run()
 	require.NoError(t, err)
 
-	d2, err := initV2Device(disk.Name(), disk)
+	d2, err := initV2Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 	_, err = d2.UnsealVolume(0, []byte(password))
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestConvertV1toV2(t *testing.T) {
 	err = exec.Command("cryptsetup", "convert", "--type", "luks1", disk.Name()).Run()
 	require.NoError(t, err)
 
-	d3, err := initV1Device(disk.Name(), disk)
+	d3, err := initV1Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 	_, err = d3.UnsealVolume(0, []byte(password))
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestConvertV2toV1(t *testing.T) {
 	defer disk.Close()
 	defer os.Remove(disk.Name())
 
-	d, err := initV2Device(disk.Name(), disk)
+	d, err := initV2Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 
 	tokens, err := d.Tokens()
@@ -101,7 +101,7 @@ func TestConvertV2toV1(t *testing.T) {
 	err = cmd.Run()
 	require.NoError(t, err)
 
-	d2, err := initV1Device(disk.Name(), disk)
+	d2, err := initV1Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 	_, err = d2.UnsealVolume(0, []byte(password))
 	require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestConvertV2toV1(t *testing.T) {
 	err = exec.Command("cryptsetup", "convert", "--type", "luks2", disk.Name()).Run()
 	require.NoError(t, err)
 
-	d3, err := initV2Device(disk.Name(), disk)
+	d3, err := initV2Device(disk.Name(), disk, disk)
 	require.NoError(t, err)
 	_, err = d3.UnsealVolume(0, []byte(password))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Add `OpenWithHeader(devicePath, headerPath string) (Device, error)` to open LUKS volumes where the header is stored separately from the encrypted data (the `--header` option in cryptsetup)
- Refactor `deviceV1`/`deviceV2` to hold separate `hdrF`/`dataF` file handles: keyslot material is read from the header file, storage size from the data device
- When the header is embedded (the normal case), `Open` passes the same file for both — no behaviour change for existing callers
- Fix a file-handle leak on the error path in `OpenWithHeader` when `initV1Device`/`initV2Device` fails

## Backwards compatibility

- `Open` signature and semantics are unchanged
- `Device` interface is unchanged — all existing mocks/fakes continue to satisfy it
- `OpenWithHeader` is a pure addition to the public API

## Tests

- `TestLuks1DetachedHeader` — integration test: creates a LUKS1 volume with `cryptsetup luksFormat --header`, unlocks via `OpenWithHeader`
- `TestLuks2DetachedHeader` — same for LUKS2
- Unit tests covering error paths: missing device file, missing header file, invalid magic bytes, unsupported LUKS version

## Context

This is used by [anatol/booster](https://github.com/anatol/booster) to support the `header=` option in `/etc/crypttab.initramfs`, allowing boot-time unlock of LUKS volumes with detached headers. A companion PR to booster depends on this change.