### PR TITLE
Add Volume.HMAC for binding values to the unlocked volume

### DIFF
--- a/volume.go
+++ b/volume.go
@@ -1,6 +1,11 @@
 package luks
 
 import (
+	"crypto"
+	"crypto/hmac"
+	_ "crypto/sha1"   // register crypto.SHA1 for HMAC
+	_ "crypto/sha256" // register crypto.SHA256
+	_ "crypto/sha512" // register crypto.SHA384 and crypto.SHA512
 	"fmt"
 	"strings"
 
@@ -28,6 +33,36 @@ var flagsKernelNames = map[string]string{
 	FlagSubmitFromCryptCPUs: devmapper.CryptFlagSubmitFromCryptCPUs,
 	FlagNoReadWorkqueue:     devmapper.CryptFlagNoReadWorkqueue,
 	FlagNoWriteWorkqueue:    devmapper.CryptFlagNoWriteWorkqueue,
+}
+
+// hmacAllowedHashes restricts HMAC to standard-library hash implementations.
+// The hash is selected by a crypto.Hash identifier rather than a caller-supplied
+// constructor, so callers cannot inject an implementation that observes the
+// volume key during the HMAC computation.
+var hmacAllowedHashes = map[crypto.Hash]bool{
+	crypto.SHA1:   true,
+	crypto.SHA256: true,
+	crypto.SHA384: true,
+	crypto.SHA512: true,
+}
+
+// HMAC returns HMAC(volume key, message) using the given hash. The hash is
+// identified by a crypto.Hash value and must be one of the supported algorithms;
+// the volume key is only ever fed to a trusted standard-library implementation.
+// It never leaves the package — callers receive only the resulting digest, which
+// carries no key material. This lets a consumer bind a value to the unlocked
+// volume (e.g. measure it into a TPM PCR) without the master key crossing the
+// package boundary.
+func (v *Volume) HMAC(h crypto.Hash, message []byte) ([]byte, error) {
+	if !hmacAllowedHashes[h] {
+		return nil, fmt.Errorf("luks: HMAC: unsupported hash %s", h)
+	}
+	if !h.Available() {
+		return nil, fmt.Errorf("luks: HMAC: hash %s is not available", h)
+	}
+	mac := hmac.New(h.New, v.key)
+	mac.Write(message)
+	return mac.Sum(nil), nil
 }
 
 // SetupMapper creates a device mapper for the given LUKS volume

--- a/volume_hmac_test.go
+++ b/volume_hmac_test.go
@@ -1,0 +1,41 @@
+package luks
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestVolumeHMAC verifies Volume.HMAC computes HMAC(volume key, message) with
+// the requested standard-library hash, without exposing the key. Consumers
+// (e.g. booster's PCR15 latch) use this to bind a value to the unlocked volume —
+// the digest is the only thing that leaves the package.
+func TestVolumeHMAC(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	v := &Volume{key: key}
+	msg := []byte("cryptsetup:cryptroot:5cbc48ce-0e78-4c6b-ac90-a8a540514b90")
+
+	got256, err := v.HMAC(crypto.SHA256, msg)
+	require.NoError(t, err)
+	want256 := hmac.New(sha256.New, key)
+	want256.Write(msg)
+	require.Equal(t, want256.Sum(nil), got256, "HMAC-SHA256")
+
+	got1, err := v.HMAC(crypto.SHA1, msg)
+	require.NoError(t, err)
+	want1 := hmac.New(sha1.New, key)
+	want1.Write(msg)
+	require.Equal(t, want1.Sum(nil), got1, "HMAC-SHA1 (per-bank hash)")
+}
+
+// TestVolumeHMACRejectsUnsupportedHash ensures a hash outside the allowlist is
+// refused rather than used — callers cannot smuggle in an untrusted algorithm.
+func TestVolumeHMACRejectsUnsupportedHash(t *testing.T) {
+	v := &Volume{key: []byte("0123456789abcdef0123456789abcdef")}
+	_, err := v.HMAC(crypto.MD5, []byte("x"))
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

Adds `func (v *Volume) HMAC(newHash func() hash.Hash, message []byte) []byte`,
returning `HMAC(volume_key, message)` computed with a caller-supplied hash.

## Why

Allows a consumer to bind a value to an unlocked volume's identity
without ever handling the master key itself. The motivating use case is
booster's defense against TPM2 filesystem-supplantation (anatol/booster#379):
after unsealing, booster measures the volume key into TPM PCR 15 — matching
systemd-cryptsetup's `tpm2-measure-pcr=`, which extends
`HMAC-<bank>(volume_key, "cryptsetup:" + name + ":" + uuid)` — so a key sealed
to an uninitialized PCR 15 can no longer be re-unsealed for the rest of the
boot.

The only alternative currently is exposing the raw `key` field, which
should be kept private.

## Design

`HMAC` keeps the master key inside the package: the caller receives only the
digest, which is the value it measures/publishes anyway and reveals nothing
about the key (HMAC is a PRF). This is stricter than libcryptsetup's
`crypt_volume_key_get`, which hands the raw key to the caller. The hash is
caller-chosen so a consumer can produce a per-bank digest (e.g. HMAC-SHA256 and
HMAC-SHA1 for the corresponding TPM PCR banks).

## Testing

`TestVolumeHMAC` checks the output matches `hmac.New(hash, key)` over a message
for both SHA-256 and SHA-1.
