### PR TITLE
Add OPAL hardware encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Requires Linux (uses device-mapper via `/dev/mapper`).
 - Token metadata (clevis, systemd-fido2, etc.)
 - LUKS v2 keyslot priorities
 - Multi-segment LUKS2 layouts (e.g. integrity)
+- TCG OPAL self-encrypting drives (cryptsetup `--hw-opal` and `--hw-opal-only`
+  segments): the locking range is unlocked through the kernel SED interface
+  (`CONFIG_BLK_SED_OPAL`) and mapped with dm-linear or dm-crypt; active
+  devices carry the same `CRYPT-LUKS2-OPAL-...` dm UUID as cryptsetup
+
+Note: LUKS2 mandatory requirements are enforced at unseal time. Devices whose
+header carries a requirement this library does not implement (e.g.
+`online-reencrypt-v2` while a re-encryption is in progress) are refused,
+matching cryptsetup's behavior.
 
 ## Usage
 

--- a/json_metadata.go
+++ b/json_metadata.go
@@ -6,11 +6,11 @@ import (
 )
 
 type keyslot struct {
-	Type     string       `json:"type"`
-	KeySize  uint         `json:"key_size"`
-	Af       antiForensic `json:"af"`
-	Area     area         `json:"area"`
-	Kdf      kdf          `json:"kdf"`
+	Type    string       `json:"type"`
+	KeySize uint         `json:"key_size"`
+	Af      antiForensic `json:"af"`
+	Area    area         `json:"area"`
+	Kdf     kdf          `json:"kdf"`
 	// Priority is a pointer to distinguish three states:
 	// nil = normal priority (default), 0 = ignore (skip slot), 1 = normal, 2 = high (prefer)
 	Priority *int `json:"priority"`
@@ -52,6 +52,13 @@ type segment struct {
 	Encryption string      `json:"encryption"`
 	SectorSize uint        `json:"sector_size"`
 	Flags      []string    `json:"flags"`
+
+	// OPAL fields, present only for segment types "hw-opal" and
+	// "hw-opal-crypt" (cryptsetup >= 2.7). A pure "hw-opal" segment carries
+	// none of the encryption/sector_size/iv_tweak fields above.
+	OpalSegmentNumber uint   `json:"opal_segment_number"` // OPAL locking-range index
+	OpalKeySize       uint   `json:"opal_key_size"`       // bytes; prefix of the keyslot key
+	OpalSegmentSize   string `json:"opal_segment_size"`   // decimal byte count of the locking range
 }
 
 type digest struct {

--- a/json_metadata_test.go
+++ b/json_metadata_test.go
@@ -99,6 +99,64 @@ func TestConfigFlagsAbsent(t *testing.T) {
 	require.Nil(t, meta.Config.Flags)
 }
 
+// TestSegmentHwOpal verifies parsing of a pure "hw-opal" segment (cryptsetup
+// --hw-opal-only). Such segments carry the OPAL fields but none of the
+// software-encryption fields: encryption, sector_size and iv_tweak are absent.
+func TestSegmentHwOpal(t *testing.T) {
+	data, err := os.ReadFile("testdata/metadata/hw_opal.json")
+	require.NoError(t, err)
+
+	var meta metadata
+	require.NoError(t, json.Unmarshal(data, &meta))
+
+	seg := meta.Segments[0]
+	require.Equal(t, "hw-opal", seg.Type)
+	require.Equal(t, uint(3), seg.OpalSegmentNumber)
+	require.Equal(t, uint(32), seg.OpalKeySize)
+	require.Equal(t, "1073741824", seg.OpalSegmentSize)
+	require.Equal(t, "16777216", seg.Offset.String())
+	require.Equal(t, "1073741824", seg.Size)
+	// no software encryption on a pure hw-opal segment
+	require.Equal(t, "", seg.Encryption)
+	require.Equal(t, uint(0), seg.SectorSize)
+	require.Equal(t, "", seg.IvTweak.String())
+	require.ElementsMatch(t, []string{"opal"}, []string(meta.Config.Requirements))
+}
+
+// TestSegmentHwOpalCrypt verifies parsing of a "hw-opal-crypt" segment
+// (cryptsetup --hw-opal): OPAL fields plus the usual software crypt fields.
+func TestSegmentHwOpalCrypt(t *testing.T) {
+	data, err := os.ReadFile("testdata/metadata/hw_opal_crypt.json")
+	require.NoError(t, err)
+
+	var meta metadata
+	require.NoError(t, json.Unmarshal(data, &meta))
+
+	seg := meta.Segments[0]
+	require.Equal(t, "hw-opal-crypt", seg.Type)
+	require.Equal(t, uint(3), seg.OpalSegmentNumber)
+	require.Equal(t, uint(32), seg.OpalKeySize)
+	require.Equal(t, "1073741824", seg.OpalSegmentSize)
+	require.Equal(t, "aes-xts-plain64", seg.Encryption)
+	require.Equal(t, uint(512), seg.SectorSize)
+	require.Equal(t, uint(96), meta.Keyslots[0].KeySize)
+}
+
+// TestSegmentOpalFieldsAbsent verifies that ordinary crypt segments parse with
+// zero-valued OPAL fields.
+func TestSegmentOpalFieldsAbsent(t *testing.T) {
+	data, err := os.ReadFile("testdata/metadata/1.json")
+	require.NoError(t, err)
+
+	var meta metadata
+	require.NoError(t, json.Unmarshal(data, &meta))
+
+	seg := meta.Segments[0]
+	require.Equal(t, uint(0), seg.OpalSegmentNumber)
+	require.Equal(t, uint(0), seg.OpalKeySize)
+	require.Equal(t, "", seg.OpalSegmentSize)
+}
+
 // TestRequirementsRoundtrip verifies that inline JSON with requirements in both
 // formats is handled correctly.
 func TestRequirementsRoundtrip(t *testing.T) {

--- a/luks.go
+++ b/luks.go
@@ -127,7 +127,12 @@ func OpenWithHeader(devicePath, headerPath string) (Device, error) {
 	return dev, err
 }
 
-// Lock closes device mapper partition with the given name
+// Lock closes the device mapper partition with the given name.
+//
+// For TCG OPAL volumes this removes only the dm device; the drive's locking
+// range stays unlocked until the next power-off (resume from S3 re-applies
+// the state recorded at unlock time). Re-locking here would need the backing
+// device and the range key, which a bare dm name does not provide.
 func Lock(name string) error {
 	return devmapper.Remove(name)
 }

--- a/luks1.go
+++ b/luks1.go
@@ -129,7 +129,7 @@ func (d *deviceV1) Unlock(keyslot int, passphrase []byte, dmName string) error {
 	if err != nil {
 		return err
 	}
-	defer clearSlice(volume.key)
+	defer volume.Clear()
 
 	return volume.SetupMapper(dmName)
 }
@@ -147,6 +147,7 @@ func (d *deviceV1) UnlockAny(passphrase []byte, dmName string) error {
 		} else if err != nil {
 			return err
 		}
+		defer volume.Clear()
 
 		return volume.SetupMapper(dmName)
 	}

--- a/luks2.go
+++ b/luks2.go
@@ -215,7 +215,7 @@ func (d *deviceV2) Unlock(keyslot int, passphrase []byte, dmName string) error {
 	if err != nil {
 		return err
 	}
-	defer clearSlice(volume.key)
+	defer volume.Clear()
 
 	return volume.SetupMapper(dmName)
 }
@@ -229,10 +229,32 @@ func (d *deviceV2) UnlockAny(passphrase []byte, dmName string) error {
 		} else if err != nil {
 			return err
 		}
+		defer volume.Clear()
 
 		return volume.SetupMapper(dmName)
 	}
 	return ErrPassphraseDoesNotMatch
+}
+
+// supportedRequirements lists the LUKS2 mandatory requirements this library
+// implements. A device carrying any other mandatory requirement must not be
+// activated: the unknown feature may change how the data area is mapped
+// (e.g. online reencryption), so proceeding could corrupt data.
+var supportedRequirements = map[string]bool{
+	"opal": true, // TCG OPAL hardware encryption (cryptsetup >= 2.7)
+}
+
+// checkRequirements refuses to proceed when the header carries a mandatory
+// requirement this library does not implement. Enforced at unseal time rather
+// than open time so that read-only introspection (Slots, Tokens, UUID) keeps
+// working on such devices, mirroring cryptsetup's luksDump behavior.
+func (d *deviceV2) checkRequirements() error {
+	for _, r := range d.meta.Config.Requirements {
+		if !supportedRequirements[r] {
+			return fmt.Errorf("LUKS2 device has unsupported mandatory requirement %q", r)
+		}
+	}
+	return nil
 }
 
 // UnsealVolume implements Device.UnsealVolume for LUKS v2 devices.
@@ -240,6 +262,10 @@ func (d *deviceV2) UnlockAny(passphrase []byte, dmName string) error {
 // decrypts the keyslot area, recovers the volume key, and verifies it against
 // the digest entry associated with this keyslot.
 func (d *deviceV2) UnsealVolume(keyslotIdx int, passphrase []byte) (*Volume, error) {
+	if err := d.checkRequirements(); err != nil {
+		return nil, err
+	}
+
 	keyslots := d.meta.Keyslots
 
 	keyslot, ok := keyslots[keyslotIdx]
@@ -279,7 +305,7 @@ func (d *deviceV2) UnsealVolume(keyslotIdx int, passphrase []byte) (*Volume, err
 	}
 	clearSlice(generatedDigest)
 
-	storageSegment, err := d.findCryptSegment(digest)
+	storageSegment, err := d.findStorageSegment(digest)
 	if err != nil {
 		return nil, err
 	}
@@ -313,9 +339,13 @@ func (d *deviceV2) UnsealVolume(keyslotIdx int, passphrase []byte) (*Volume, err
 		storageSize = uint64(size)
 	}
 
-	ivTweak, err := storageSegment.IvTweak.Int64()
-	if err != nil {
-		return nil, err
+	// pure "hw-opal" segments have no iv_tweak field
+	var ivTweak int64
+	if storageSegment.Type != "hw-opal" {
+		ivTweak, err = storageSegment.IvTweak.Int64()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	v := &Volume{
@@ -329,7 +359,26 @@ func (d *deviceV2) UnsealVolume(keyslotIdx int, passphrase []byte) (*Volume, err
 		StorageEncryption: storageSegment.Encryption,
 		StorageIvTweak:    uint64(ivTweak),
 		StorageSectorSize: uint64(storageSegment.SectorSize),
+		segmentType:       storageSegment.Type,
 	}
+
+	if storageSegment.Type == "hw-opal" || storageSegment.Type == "hw-opal-crypt" {
+		opal, err := parseOpalSegment(storageSegment, len(finalKey))
+		if err != nil {
+			return nil, err
+		}
+		// the dm UUID type cryptsetup uses for OPAL-backed devices; the
+		// only OPAL marker available once a device is active
+		v.LuksType = "LUKS2-OPAL"
+		v.opalKeySize = opal.keySize
+		v.opalSegmentNumber = opal.segmentNumber
+		v.opalSegmentSize = opal.segmentSize
+		if storageSegment.Type == "hw-opal" {
+			// cryptsetup's default for segments without a sector_size field
+			v.StorageSectorSize = 512
+		}
+	}
+
 	return v, nil
 }
 
@@ -471,10 +520,19 @@ func (d *deviceV2) findDigestForKeyslot(keyslotIdx int) *digest {
 	return nil
 }
 
-// findCryptSegment returns the first segment of type "crypt" referenced by the
-// given digest. This handles the multi-segment case (e.g. integrity layouts)
-// where a digest may cover both a "crypt" and a "linear" segment.
-func (d *deviceV2) findCryptSegment(dig *digest) (*segment, error) {
+// storageSegmentTypes are the segment types this library can activate:
+// software dm-crypt ("crypt") and the TCG OPAL hardware-encryption types
+// introduced by cryptsetup 2.7.
+var storageSegmentTypes = map[string]bool{
+	"crypt":         true,
+	"hw-opal":       true,
+	"hw-opal-crypt": true,
+}
+
+// findStorageSegment returns the first activatable storage segment referenced
+// by the given digest. This handles the multi-segment case (e.g. integrity
+// layouts) where a digest may cover both a storage and a "linear" segment.
+func (d *deviceV2) findStorageSegment(dig *digest) (*segment, error) {
 	for _, segNum := range dig.Segments {
 		segID, err := segNum.Int64()
 		if err != nil {
@@ -484,9 +542,9 @@ func (d *deviceV2) findCryptSegment(dig *digest) (*segment, error) {
 		if !ok {
 			continue
 		}
-		if seg.Type == "crypt" {
+		if storageSegmentTypes[seg.Type] {
 			return &seg, nil
 		}
 	}
-	return nil, fmt.Errorf("no crypt segment found in digest (segments: %v)", dig.Segments)
+	return nil, fmt.Errorf("no storage segment found in digest (segments: %v)", dig.Segments)
 }

--- a/luks2_test.go
+++ b/luks2_test.go
@@ -1,6 +1,7 @@
 package luks
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -234,4 +235,62 @@ func TestLuks2PreferedPriority(t *testing.T) {
 	require.NoError(t, err)
 
 	require.ElementsMatch(t, []int{0}, d.Slots())
+}
+
+// TestCheckRequirements verifies that mandatory LUKS2 requirements gate
+// unsealing: supported requirements pass, unknown ones produce an error.
+func TestCheckRequirements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		requirements []string
+		wantErr      string
+	}{
+		{name: "absent", requirements: nil},
+		{name: "opal", requirements: []string{"opal"}},
+		// a -vN suffix means incompatible new semantics; must not be pre-approved
+		{name: "unknown opal version", requirements: []string{"opal-v2"}, wantErr: `unsupported mandatory requirement "opal-v2"`},
+		{name: "unknown", requirements: []string{"online-reencrypt-v2"}, wantErr: `unsupported mandatory requirement "online-reencrypt-v2"`},
+		{name: "mixed known and unknown", requirements: []string{"opal", "inline-hw-tags"}, wantErr: `unsupported mandatory requirement "inline-hw-tags"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &deviceV2{meta: &metadata{Config: config{Requirements: tc.requirements}}}
+			err := d.checkRequirements()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestFindStorageSegment verifies segment selection across the activatable
+// segment types and the skip-over-linear behavior.
+func TestFindStorageSegment(t *testing.T) {
+	t.Parallel()
+
+	mkDev := func(segType string) *deviceV2 {
+		return &deviceV2{meta: &metadata{
+			Segments: map[int]segment{
+				0: {Type: "linear"},
+				1: {Type: segType},
+			},
+		}}
+	}
+	dig := &digest{Segments: []json.Number{"0", "1"}}
+
+	for _, segType := range []string{"crypt", "hw-opal", "hw-opal-crypt"} {
+		d := mkDev(segType)
+		seg, err := d.findStorageSegment(dig)
+		require.NoError(t, err, segType)
+		require.Equal(t, segType, seg.Type)
+	}
+
+	d := mkDev("linear")
+	_, err := d.findStorageSegment(dig)
+	require.ErrorContains(t, err, "no storage segment found")
 }

--- a/opal.go
+++ b/opal.go
@@ -1,0 +1,396 @@
+package luks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Bindings for the Linux SED OPAL interface (CONFIG_BLK_SED_OPAL,
+// <linux/sed-opal.h>). Only the subset needed to unlock and re-lock a
+// locking range that cryptsetup configured at luksFormat time.
+
+// The ioctl request numbers below are precomputed with the asm-generic _IOC
+// encoding (dir<<30 | size<<16 | type<<8 | nr), which holds for amd64, 386,
+// arm, arm64, riscv64 and s390x. powerpc, mips and sparc use different
+// _IOC_* bit layouts and would need per-arch values.
+const (
+	iocOpalSave        = 0x411870DC // _IOW('p', 220, struct opal_lock_unlock)
+	iocOpalLockUnlock  = 0x411870DD // _IOW('p', 221, struct opal_lock_unlock)
+	iocOpalGetStatus   = 0x800870EC // _IOR('p', 236, struct opal_status)
+	iocOpalGetLrStatus = 0x413070ED // _IOW('p', 237, struct opal_lr_status); result copied back
+	iocOpalGetGeometry = 0x802070EE // _IOR('p', 238, struct opal_geometry)
+
+	// enum opal_lock_state
+	opalRO uint32 = 0x01
+	opalRW uint32 = 0x02
+	opalLK uint32 = 0x04
+
+	// enum opal_lock_flags
+	opalSaveForLock uint16 = 0x01
+
+	// enum opal_key_type
+	opalKeyIncluded uint8 = 0
+
+	// struct opal_status flags
+	opalFlSupported        uint32 = 0x01
+	opalFlLockingSupported uint32 = 0x02
+	opalFlLockingEnabled   uint32 = 0x04
+	opalFlLocked           uint32 = 0x08
+
+	// TCG method status codes returned as positive values by sed ioctls
+	opalStatusNotAuthorized = 0x01
+	opalStatusFail          = 0x3f
+
+	opalKeyMax = 256
+	// struct opal_key.key_len is a __u8, so the largest representable key
+	// is one byte shorter than the key array
+	opalKeyMaxLen = 255
+
+	// who = segment number + 1 must not exceed OPAL_USER9 (9)
+	opalMaxSegmentNumber = 8
+)
+
+// Layouts mirror <linux/sed-opal.h>. All fields are fixed-width with
+// explicit padding, so the Go structs match the C ABI on all 64-bit
+// architectures. Sizes are asserted at compile time below; a silent
+// mismatch would corrupt the ioctl arguments.
+
+type opalKeyC struct {
+	LR      uint8
+	KeyLen  uint8
+	KeyType uint8 // must be opalKeyIncluded; OPAL_KEYRING would make the kernel ignore Key
+	pad     [5]uint8
+	Key     [opalKeyMax]uint8
+}
+
+type opalSessionInfo struct {
+	SUM uint32
+	Who uint32
+	Key opalKeyC
+}
+
+type opalLockUnlock struct {
+	Session opalSessionInfo
+	LState  uint32
+	Flags   uint16
+	pad     [2]uint8
+}
+
+type opalStatus struct {
+	Flags    uint32
+	Reserved uint32
+}
+
+type opalGeometry struct {
+	Align                uint8
+	pad0                 [3]uint8
+	LogicalBlockSize     uint32
+	AlignmentGranularity uint64
+	LowestAlignedLBA     uint64
+	pad1                 [8]uint8
+}
+
+type opalLrStatus struct {
+	Session     opalSessionInfo
+	RangeStart  uint64
+	RangeLength uint64
+	RLE         uint32
+	WLE         uint32
+	LState      uint32
+	pad         [4]uint8
+}
+
+// compile-time layout assertions against the kernel ABI
+var (
+	_ = [1]struct{}{}[unsafe.Sizeof(opalKeyC{})-264]
+	_ = [1]struct{}{}[unsafe.Sizeof(opalSessionInfo{})-272]
+	_ = [1]struct{}{}[unsafe.Sizeof(opalLockUnlock{})-280]
+	_ = [1]struct{}{}[unsafe.Sizeof(opalStatus{})-8]
+	_ = [1]struct{}{}[unsafe.Sizeof(opalGeometry{})-32]
+	_ = [1]struct{}{}[unsafe.Sizeof(opalLrStatus{})-304]
+)
+
+// ErrOpalNotAuthorized means the drive rejected the locking-range key. It is
+// deliberately distinct from ErrPassphraseDoesNotMatch: by the time an OPAL
+// ioctl runs, the passphrase has already passed LUKS digest verification, so
+// the header and the drive credential have diverged (e.g. after a factory
+// reset) and re-prompting the user cannot help.
+var ErrOpalNotAuthorized = errors.New("OPAL: drive not authorized (locking-range key does not match LUKS header)")
+
+// opalIoctl is the single impure call in this file, indirected so unit tests
+// can substitute a fake without OPAL hardware.
+var opalIoctl = func(fd uintptr, req uintptr, arg unsafe.Pointer) (uintptr, unix.Errno) {
+	r1, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, req, uintptr(arg))
+	// unix.Syscall lacks the //go:uintptrkeepalive pragma of the syscall
+	// package, so keep the argument struct reachable across the call
+	// ourselves.
+	runtime.KeepAlive(arg)
+	return r1, errno
+}
+
+// opalStatusCodeToErr interprets the tri-state sed ioctl result: the ioctl
+// returns -errno (delivered as errno here), 0 for success, or a positive TCG
+// method status code.
+func opalStatusCodeToErr(op string, ret uintptr, errno unix.Errno) error {
+	if errno != 0 {
+		return fmt.Errorf("OPAL %s: %w", op, errno)
+	}
+	switch ret {
+	case 0:
+		return nil
+	case opalStatusNotAuthorized:
+		return fmt.Errorf("OPAL %s: %w", op, ErrOpalNotAuthorized)
+	case opalStatusFail:
+		return fmt.Errorf("OPAL %s: TCG status FAIL", op)
+	default:
+		return fmt.Errorf("OPAL %s: TCG status 0x%x", op, ret)
+	}
+}
+
+// fillOpalSession fills the session header shared by all locking-range
+// operations directly into the caller's struct, so the key material exists in
+// exactly one place (which the caller clears): the range is owned by user
+// (segment number + 1), never Admin1, and SUM is always 0 (even on Single
+// User Mode drives the range's User authority performs lock/unlock).
+func fillOpalSession(s *opalSessionInfo, segmentNumber uint, key []byte) error {
+	if segmentNumber > opalMaxSegmentNumber {
+		return fmt.Errorf("OPAL segment number %d out of range: the kernel supports locking ranges 0..%d", segmentNumber, opalMaxSegmentNumber)
+	}
+	if len(key) > opalKeyMaxLen {
+		return fmt.Errorf("OPAL key length %d exceeds maximum %d", len(key), opalKeyMaxLen)
+	}
+	s.SUM = 0
+	s.Who = uint32(segmentNumber) + 1
+	s.Key.LR = uint8(segmentNumber)
+	s.Key.KeyType = opalKeyIncluded
+	s.Key.KeyLen = uint8(len(key))
+	copy(s.Key.Key[:], key)
+	return nil
+}
+
+func opalGetStatusIoctl(f *os.File) (*opalStatus, error) {
+	var st opalStatus
+	ret, errno := opalIoctl(f.Fd(), iocOpalGetStatus, unsafe.Pointer(&st))
+	if err := opalStatusCodeToErr("get status", ret, errno); err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+func opalGetGeometryIoctl(f *os.File) (*opalGeometry, error) {
+	var geo opalGeometry
+	ret, errno := opalIoctl(f.Fd(), iocOpalGetGeometry, unsafe.Pointer(&geo))
+	if err := opalStatusCodeToErr("get geometry", ret, errno); err != nil {
+		return nil, err
+	}
+	return &geo, nil
+}
+
+func opalGetLrStatusIoctl(f *os.File, segmentNumber uint, key []byte) (*opalLrStatus, error) {
+	var lr opalLrStatus
+	if err := fillOpalSession(&lr.Session, segmentNumber, key); err != nil {
+		return nil, err
+	}
+	// The key is zeroed before the caller sees the struct: callers only
+	// consume the range/lock-state fields, never the session key.
+	defer clearSlice(lr.Session.Key.Key[:])
+
+	ret, errno := opalIoctl(f.Fd(), iocOpalGetLrStatus, unsafe.Pointer(&lr))
+	if err := opalStatusCodeToErr("get locking range status", ret, errno); err != nil {
+		return nil, err
+	}
+	return &lr, nil
+}
+
+// opalUnlock unlocks the given locking range for read-write.
+func opalUnlock(f *os.File, segmentNumber uint, key []byte) error {
+	var lu opalLockUnlock
+	if err := fillOpalSession(&lu.Session, segmentNumber, key); err != nil {
+		return err
+	}
+	defer clearSlice(lu.Session.Key.Key[:])
+	lu.LState = opalRW
+
+	ret, errno := opalIoctl(f.Fd(), iocOpalLockUnlock, unsafe.Pointer(&lu))
+	return opalStatusCodeToErr("unlock", ret, errno)
+}
+
+// opalSaveUnlockForResume asks the kernel to remember the unlock key
+// (OPAL_SAVE_FOR_LOCK) so the range is re-unlocked transparently on resume
+// from S3 suspend, and so a later keyless opalLock can rely on the stored
+// key. SAVE never talks to the drive; it only updates the kernel's suspend
+// list, so a failure affects resume behavior, not the current unlock.
+func opalSaveUnlockForResume(f *os.File, segmentNumber uint, key []byte) error {
+	var lu opalLockUnlock
+	if err := fillOpalSession(&lu.Session, segmentNumber, key); err != nil {
+		return err
+	}
+	defer clearSlice(lu.Session.Key.Key[:])
+	lu.LState = opalRW
+	lu.Flags = opalSaveForLock
+
+	ret, errno := opalIoctl(f.Fd(), iocOpalSave, unsafe.Pointer(&lu))
+	return opalStatusCodeToErr("save", ret, errno)
+}
+
+// opalLock re-locks the locking range. With a nil key the kernel substitutes
+// the key stored by an earlier successful opalSaveUnlockForResume; pass the
+// key explicitly when that save is not known to have succeeded. The follow-up
+// SAVE records the locked state so resume from S3 re-locks rather than
+// unlocks; its failure is non-fatal since the range is already locked.
+func opalLock(f *os.File, segmentNumber uint, key []byte) error {
+	var lu opalLockUnlock
+	if err := fillOpalSession(&lu.Session, segmentNumber, key); err != nil {
+		return err
+	}
+	defer clearSlice(lu.Session.Key.Key[:])
+	lu.LState = opalLK
+
+	ret, errno := opalIoctl(f.Fd(), iocOpalLockUnlock, unsafe.Pointer(&lu))
+	if err := opalStatusCodeToErr("lock", ret, errno); err != nil {
+		return err
+	}
+
+	ret, errno = opalIoctl(f.Fd(), iocOpalSave, unsafe.Pointer(&lu))
+	_ = opalStatusCodeToErr("save", ret, errno)
+	return nil
+}
+
+// opalParams is the validated OPAL geometry of a "hw-opal" or "hw-opal-crypt"
+// segment.
+type opalParams struct {
+	segmentNumber uint
+	keySize       uint64 // bytes; prefix of the keyslot key holding the OPAL passphrase
+	segmentSize   uint64 // locking-range length in bytes
+}
+
+// parseOpalSegment validates the OPAL fields of a segment against the keyslot
+// key length, mirroring the constraints cryptsetup's header validator
+// guarantees and the kernel enforces.
+func parseOpalSegment(seg *segment, keyLen int) (*opalParams, error) {
+	if seg.Size == "dynamic" {
+		return nil, fmt.Errorf(`OPAL segment size cannot be "dynamic"`)
+	}
+	size, err := strconv.ParseUint(seg.Size, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid OPAL segment size %q: %w", seg.Size, err)
+	}
+	offset, err := seg.Offset.Int64()
+	if err != nil {
+		return nil, fmt.Errorf("invalid OPAL segment offset %q: %w", seg.Offset, err)
+	}
+	if offset%512 != 0 || size%512 != 0 {
+		return nil, fmt.Errorf("OPAL segment offset %d / size %d not 512-byte aligned", offset, size)
+	}
+
+	keySize := uint64(seg.OpalKeySize)
+	switch {
+	case keySize == 0:
+		return nil, fmt.Errorf("OPAL segment has no opal_key_size")
+	case keySize > opalKeyMaxLen:
+		return nil, fmt.Errorf("opal_key_size %d exceeds maximum %d", keySize, opalKeyMaxLen)
+	case seg.Type == "hw-opal" && keySize != uint64(keyLen):
+		return nil, fmt.Errorf("hw-opal segment expects the whole keyslot key (%d bytes) as OPAL key, got opal_key_size %d", keyLen, keySize)
+	case seg.Type == "hw-opal-crypt" && keySize >= uint64(keyLen):
+		return nil, fmt.Errorf("hw-opal-crypt opal_key_size %d leaves no dm-crypt key in the %d-byte keyslot key", keySize, keyLen)
+	}
+
+	if seg.OpalSegmentNumber > opalMaxSegmentNumber {
+		return nil, fmt.Errorf("OPAL segment number %d out of range: the kernel supports locking ranges 0..%d", seg.OpalSegmentNumber, opalMaxSegmentNumber)
+	}
+
+	segmentSize, err := strconv.ParseUint(seg.OpalSegmentSize, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid opal_segment_size %q: %w", seg.OpalSegmentSize, err)
+	}
+	if segmentSize == 0 || segmentSize%512 != 0 {
+		return nil, fmt.Errorf("opal_segment_size %d is zero or not 512-byte aligned", segmentSize)
+	}
+	// cryptsetup requires the data segment and the locking range to have
+	// the same size (a smaller segment is only allowed with integrity
+	// layouts, which this library does not support for OPAL).
+	if size != segmentSize {
+		return nil, fmt.Errorf("segment size %d must equal OPAL locking-range size %d", size, segmentSize)
+	}
+
+	return &opalParams{
+		segmentNumber: seg.OpalSegmentNumber,
+		keySize:       keySize,
+		segmentSize:   segmentSize,
+	}, nil
+}
+
+// partitionStartSector returns the start LBA (in 512-byte sectors) of the
+// given open partition block device. The sysfs node is looked up via the
+// device's major:minor so that symlinked paths (/dev/disk/by-uuid/... etc.)
+// resolve correctly. Whole-disk devices have no `start` attribute and yield
+// 0, which is also the correct offset for them.
+func partitionStartSector(f *os.File) (uint64, error) {
+	var st unix.Stat_t
+	if err := unix.Fstat(int(f.Fd()), &st); err != nil {
+		return 0, err
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFBLK {
+		return 0, fmt.Errorf("%s is not a block device", f.Name())
+	}
+	rdev := uint64(st.Rdev)
+	sysfsPath := fmt.Sprintf("/sys/dev/block/%d:%d/start", unix.Major(rdev), unix.Minor(rdev))
+	data, err := os.ReadFile(sysfsPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil // whole disk
+	}
+	if err != nil {
+		return 0, err
+	}
+	start, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing partition start of %s: %w", f.Name(), err)
+	}
+	return start, nil
+}
+
+// isOpalQueryUnsupported reports whether an error from a status/geometry
+// query means the kernel or firmware genuinely cannot answer it (as opposed
+// to refusing it, e.g. NOT_AUTHORIZED, which callers must treat as fatal).
+func isOpalQueryUnsupported(err error) bool {
+	return errors.Is(err, unix.ENOTTY) || errors.Is(err, unix.EOPNOTSUPP) || errors.Is(err, unix.ENOSYS)
+}
+
+// verifyOpalGeometry checks that the locking range the drive reports matches
+// what the LUKS2 header promises: the range must cover exactly the data
+// segment (offset relative to the partition plus the partition's own start)
+// and have both read and write lock enabled. A mismatch means the header and
+// the drive configuration have diverged; unlocking anyway would expose wrong
+// ciphertext as if it were the volume.
+func verifyOpalGeometry(lr *opalLrStatus, logicalBlockSize uint32, partStartSector, storageOffsetBytes, opalSegmentSizeBytes uint64) error {
+	if logicalBlockSize < 512 || !isPowerOfTwo(uint(logicalBlockSize)) {
+		return fmt.Errorf("OPAL: unexpected logical block size %d", logicalBlockSize)
+	}
+	sectorsPerBlock := uint64(logicalBlockSize) / 512
+
+	// Compare in drive-block units: multiplying the drive-reported values
+	// could wrap and defeat the comparison.
+	wantStart := storageOffsetBytes/512 + partStartSector
+	wantLength := opalSegmentSizeBytes / 512
+	if wantStart%sectorsPerBlock != 0 || wantLength%sectorsPerBlock != 0 {
+		return fmt.Errorf("OPAL segment (start sector %d, length %d) is not aligned to the drive's %d-byte blocks", wantStart, wantLength, logicalBlockSize)
+	}
+
+	if lr.RangeStart != wantStart/sectorsPerBlock {
+		return fmt.Errorf("OPAL locking range starts at block %d, LUKS header expects %d", lr.RangeStart, wantStart/sectorsPerBlock)
+	}
+	if lr.RangeLength != wantLength/sectorsPerBlock {
+		return fmt.Errorf("OPAL locking range is %d blocks long, LUKS header expects %d", lr.RangeLength, wantLength/sectorsPerBlock)
+	}
+	if lr.RLE == 0 || lr.WLE == 0 {
+		return fmt.Errorf("OPAL locking range has locking disabled (RLE=%d WLE=%d)", lr.RLE, lr.WLE)
+	}
+	return nil
+}

--- a/opal_test.go
+++ b/opal_test.go
@@ -1,0 +1,375 @@
+package luks
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// TestOpalStructLayout pins the field offsets of the ioctl structs to the
+// kernel ABI from <linux/sed-opal.h>. Sizes are already asserted at compile
+// time; offsets are checked here.
+func TestOpalStructLayout(t *testing.T) {
+	var k opalKeyC
+	require.Equal(t, uintptr(0), unsafe.Offsetof(k.LR))
+	require.Equal(t, uintptr(1), unsafe.Offsetof(k.KeyLen))
+	require.Equal(t, uintptr(2), unsafe.Offsetof(k.KeyType))
+	require.Equal(t, uintptr(8), unsafe.Offsetof(k.Key))
+
+	var s opalSessionInfo
+	require.Equal(t, uintptr(0), unsafe.Offsetof(s.SUM))
+	require.Equal(t, uintptr(4), unsafe.Offsetof(s.Who))
+	require.Equal(t, uintptr(8), unsafe.Offsetof(s.Key))
+
+	var lu opalLockUnlock
+	require.Equal(t, uintptr(0), unsafe.Offsetof(lu.Session))
+	require.Equal(t, uintptr(272), unsafe.Offsetof(lu.LState))
+	require.Equal(t, uintptr(276), unsafe.Offsetof(lu.Flags))
+
+	var geo opalGeometry
+	require.Equal(t, uintptr(4), unsafe.Offsetof(geo.LogicalBlockSize))
+	require.Equal(t, uintptr(8), unsafe.Offsetof(geo.AlignmentGranularity))
+	require.Equal(t, uintptr(16), unsafe.Offsetof(geo.LowestAlignedLBA))
+
+	var lr opalLrStatus
+	require.Equal(t, uintptr(272), unsafe.Offsetof(lr.RangeStart))
+	require.Equal(t, uintptr(280), unsafe.Offsetof(lr.RangeLength))
+	require.Equal(t, uintptr(288), unsafe.Offsetof(lr.RLE))
+	require.Equal(t, uintptr(292), unsafe.Offsetof(lr.WLE))
+	require.Equal(t, uintptr(296), unsafe.Offsetof(lr.LState))
+}
+
+func TestOpalStatusCodeToErr(t *testing.T) {
+	require.NoError(t, opalStatusCodeToErr("op", 0, 0))
+	require.ErrorIs(t, opalStatusCodeToErr("op", opalStatusNotAuthorized, 0), ErrOpalNotAuthorized)
+	require.ErrorContains(t, opalStatusCodeToErr("op", opalStatusFail, 0), "TCG status FAIL")
+	require.ErrorContains(t, opalStatusCodeToErr("op", 0x24, 0), "TCG status 0x24")
+	require.ErrorIs(t, opalStatusCodeToErr("op", 0, unix.ENOTTY), unix.ENOTTY)
+}
+
+func TestFillOpalSession(t *testing.T) {
+	key := []byte("secret-opal-key")
+	var s opalSessionInfo
+	require.NoError(t, fillOpalSession(&s, 3, key))
+	require.Equal(t, uint32(0), s.SUM)
+	require.Equal(t, uint32(4), s.Who) // segment number + 1, never Admin1
+	require.Equal(t, uint8(3), s.Key.LR)
+	require.Equal(t, opalKeyIncluded, s.Key.KeyType)
+	require.Equal(t, uint8(len(key)), s.Key.KeyLen)
+	require.True(t, bytes.Equal(s.Key.Key[:len(key)], key))
+
+	require.ErrorContains(t, fillOpalSession(&s, 9, key), "segment number 9 out of range")
+	require.ErrorContains(t, fillOpalSession(&s, 0, make([]byte, 256)), "exceeds maximum 255")
+}
+
+// fakeOpalCall captures one ioctl invocation made through the test seam.
+type fakeOpalCall struct {
+	req    uintptr
+	lu     opalLockUnlock // deep copy taken at call time
+	keyDup []byte
+}
+
+func withFakeOpalIoctl(t *testing.T, handler func(req uintptr, arg unsafe.Pointer) (uintptr, unix.Errno)) *[]fakeOpalCall {
+	t.Helper()
+	var calls []fakeOpalCall
+	orig := opalIoctl
+	opalIoctl = func(fd uintptr, req uintptr, arg unsafe.Pointer) (uintptr, unix.Errno) {
+		call := fakeOpalCall{req: req}
+		if req == iocOpalLockUnlock || req == iocOpalSave {
+			lu := (*opalLockUnlock)(arg)
+			call.lu = *lu
+			call.keyDup = append([]byte(nil), lu.Session.Key.Key[:lu.Session.Key.KeyLen]...)
+		}
+		calls = append(calls, call)
+		return handler(req, arg)
+	}
+	t.Cleanup(func() { opalIoctl = orig })
+	return &calls
+}
+
+func TestOpalUnlockSequence(t *testing.T) {
+	calls := withFakeOpalIoctl(t, func(req uintptr, arg unsafe.Pointer) (uintptr, unix.Errno) {
+		return 0, 0
+	})
+
+	f, err := os.CreateTemp(t.TempDir(), "fakedev")
+	require.NoError(t, err)
+	defer f.Close()
+
+	key := []byte("opal-range-key")
+	require.NoError(t, opalUnlock(f, 2, key))
+	require.NoError(t, opalSaveUnlockForResume(f, 2, key))
+
+	require.Len(t, *calls, 2)
+
+	unlock := (*calls)[0]
+	require.Equal(t, uintptr(iocOpalLockUnlock), unlock.req)
+	require.Equal(t, opalRW, unlock.lu.LState)
+	require.Equal(t, uint16(0), unlock.lu.Flags)
+	require.Equal(t, uint32(3), unlock.lu.Session.Who)
+	require.Equal(t, uint32(0), unlock.lu.Session.SUM)
+	require.Equal(t, uint8(2), unlock.lu.Session.Key.LR)
+	require.Equal(t, key, unlock.keyDup)
+
+	save := (*calls)[1]
+	require.Equal(t, uintptr(iocOpalSave), save.req)
+	require.Equal(t, opalRW, save.lu.LState)
+	require.Equal(t, opalSaveForLock, save.lu.Flags)
+	require.Equal(t, key, save.keyDup)
+}
+
+func TestOpalUnlockNotAuthorized(t *testing.T) {
+	withFakeOpalIoctl(t, func(req uintptr, arg unsafe.Pointer) (uintptr, unix.Errno) {
+		if req == iocOpalLockUnlock {
+			return opalStatusNotAuthorized, 0
+		}
+		return 0, 0
+	})
+
+	f, err := os.CreateTemp(t.TempDir(), "fakedev")
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.ErrorIs(t, opalUnlock(f, 0, []byte("bad")), ErrOpalNotAuthorized)
+}
+
+func TestOpalSaveFailureIsSeparate(t *testing.T) {
+	withFakeOpalIoctl(t, func(req uintptr, arg unsafe.Pointer) (uintptr, unix.Errno) {
+		if req == iocOpalSave {
+			return 0, unix.EOPNOTSUPP
+		}
+		return 0, 0
+	})
+
+	f, err := os.CreateTemp(t.TempDir(), "fakedev")
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.NoError(t, opalUnlock(f, 0, []byte("key"))) // unlock unaffected
+	require.ErrorIs(t, opalSaveUnlockForResume(f, 0, []byte("key")), unix.EOPNOTSUPP)
+}
+
+func TestOpalLockSequence(t *testing.T) {
+	calls := withFakeOpalIoctl(t, func(req uintptr, arg unsafe.Pointer) (uintptr, unix.Errno) {
+		return 0, 0
+	})
+
+	f, err := os.CreateTemp(t.TempDir(), "fakedev")
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.NoError(t, opalLock(f, 1, nil))
+	require.Len(t, *calls, 2)
+
+	lock := (*calls)[0]
+	require.Equal(t, uintptr(iocOpalLockUnlock), lock.req)
+	require.Equal(t, opalLK, lock.lu.LState)
+	require.Equal(t, uint8(0), lock.lu.Session.Key.KeyLen) // kernel substitutes saved key
+	require.Equal(t, uint16(0), lock.lu.Flags)
+
+	save := (*calls)[1]
+	require.Equal(t, uintptr(iocOpalSave), save.req)
+	require.Equal(t, opalLK, save.lu.LState)
+	require.Equal(t, uint16(0), save.lu.Flags) // overwrite saved entry: resume must re-lock
+}
+
+// TestOpalLockWithExplicitKey covers the re-lock-on-error path, where the key
+// is passed explicitly because the earlier save may not have succeeded.
+func TestOpalLockWithExplicitKey(t *testing.T) {
+	calls := withFakeOpalIoctl(t, func(req uintptr, arg unsafe.Pointer) (uintptr, unix.Errno) {
+		return 0, 0
+	})
+
+	f, err := os.CreateTemp(t.TempDir(), "fakedev")
+	require.NoError(t, err)
+	defer f.Close()
+
+	key := []byte("opal-range-key")
+	require.NoError(t, opalLock(f, 1, key))
+	lock := (*calls)[0]
+	require.Equal(t, opalLK, lock.lu.LState)
+	require.Equal(t, key, lock.keyDup)
+}
+
+func TestVerifyOpalGeometry(t *testing.T) {
+	// partition at LBA 2048, LUKS data offset 16 MiB, range 1 GiB, 512B blocks
+	good := &opalLrStatus{
+		RangeStart:  2048 + 16*1024*1024/512,
+		RangeLength: 1024 * 1024 * 1024 / 512,
+		RLE:         1,
+		WLE:         1,
+	}
+	require.NoError(t, verifyOpalGeometry(good, 512, 2048, 16*1024*1024, 1024*1024*1024))
+
+	// same drive reporting in 4096-byte blocks
+	good4k := &opalLrStatus{
+		RangeStart:  (2048 + 16*1024*1024/512) / 8,
+		RangeLength: 1024 * 1024 * 1024 / 4096,
+		RLE:         1,
+		WLE:         1,
+	}
+	require.NoError(t, verifyOpalGeometry(good4k, 4096, 2048, 16*1024*1024, 1024*1024*1024))
+
+	badStart := &opalLrStatus{RangeStart: 1, RangeLength: good.RangeLength, RLE: 1, WLE: 1}
+	require.ErrorContains(t, verifyOpalGeometry(badStart, 512, 2048, 16*1024*1024, 1024*1024*1024), "starts at block")
+
+	badLen := &opalLrStatus{RangeStart: good.RangeStart, RangeLength: 1, RLE: 1, WLE: 1}
+	require.ErrorContains(t, verifyOpalGeometry(badLen, 512, 2048, 16*1024*1024, 1024*1024*1024), "blocks long")
+
+	// a segment whose sector boundaries don't fall on drive blocks must
+	// be rejected, not silently truncated by integer division
+	require.ErrorContains(t, verifyOpalGeometry(good4k, 4096, 2049, 16*1024*1024, 1024*1024*1024), "not aligned to the drive's 4096-byte blocks")
+
+	noLock := &opalLrStatus{RangeStart: good.RangeStart, RangeLength: good.RangeLength}
+	require.ErrorContains(t, verifyOpalGeometry(noLock, 512, 2048, 16*1024*1024, 1024*1024*1024), "locking disabled")
+
+	require.ErrorContains(t, verifyOpalGeometry(good, 256, 2048, 16*1024*1024, 1024*1024*1024), "unexpected logical block size")
+	require.ErrorContains(t, verifyOpalGeometry(good, 1536, 2048, 16*1024*1024, 1024*1024*1024), "unexpected logical block size")
+}
+
+func TestParseOpalSegment(t *testing.T) {
+	base := func() *segment {
+		return &segment{
+			Type:              "hw-opal",
+			Offset:            "16777216",
+			Size:              "1073741824",
+			OpalSegmentNumber: 3,
+			OpalKeySize:       32,
+			OpalSegmentSize:   "1073741824",
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mod     func(*segment)
+		keyLen  int
+		wantErr string
+	}{
+		{name: "hw-opal happy path", mod: func(s *segment) {}, keyLen: 32},
+		{
+			name: "hw-opal-crypt happy path",
+			mod: func(s *segment) {
+				s.Type = "hw-opal-crypt"
+				s.Encryption = "aes-xts-plain64"
+				s.SectorSize = 512
+			},
+			keyLen: 96,
+		},
+		{
+			name:    "dynamic size rejected",
+			mod:     func(s *segment) { s.Size = "dynamic" },
+			keyLen:  32,
+			wantErr: `cannot be "dynamic"`,
+		},
+		{
+			name:    "hw-opal with crypt remainder",
+			mod:     func(s *segment) {},
+			keyLen:  96,
+			wantErr: "expects the whole keyslot key",
+		},
+		{
+			name:    "hw-opal-crypt key too short",
+			mod:     func(s *segment) { s.Type = "hw-opal-crypt" },
+			keyLen:  32,
+			wantErr: "leaves no dm-crypt key",
+		},
+		{
+			name:    "zero key size",
+			mod:     func(s *segment) { s.OpalKeySize = 0 },
+			keyLen:  32,
+			wantErr: "no opal_key_size",
+		},
+		{
+			name:    "key size above kernel limit",
+			mod:     func(s *segment) { s.OpalKeySize = 256 },
+			keyLen:  256,
+			wantErr: "exceeds maximum 255",
+		},
+		{
+			name:    "segment number above kernel limit",
+			mod:     func(s *segment) { s.OpalSegmentNumber = 9 },
+			keyLen:  32,
+			wantErr: "out of range",
+		},
+		{
+			name:    "unaligned locking range",
+			mod:     func(s *segment) { s.OpalSegmentSize = "1073741825"; s.Size = "1024" },
+			keyLen:  32,
+			wantErr: "not 512-byte aligned",
+		},
+		{
+			name:    "unaligned offset",
+			mod:     func(s *segment) { s.Offset = "100" },
+			keyLen:  32,
+			wantErr: "not 512-byte aligned",
+		},
+		{
+			name:    "data segment size differs from locking range",
+			mod:     func(s *segment) { s.OpalSegmentSize = "512" },
+			keyLen:  32,
+			wantErr: "must equal OPAL locking-range size",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			seg := base()
+			tc.mod(seg)
+			p, err := parseOpalSegment(seg, tc.keyLen)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, uint(3), p.segmentNumber)
+				require.Equal(t, uint64(32), p.keySize)
+				require.Equal(t, uint64(1073741824), p.segmentSize)
+			} else {
+				require.ErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestOpalRealHardware exercises the full unlock path against a real OPAL
+// LUKS2 device. It requires SED hardware, root, and a device formatted with
+// cryptsetup --hw-opal or --hw-opal-only, so it is gated behind environment
+// variables and never runs in CI (QEMU cannot emulate OPAL):
+//
+//	sudo LUKS_OPAL_TEST_DEVICE=/dev/nvme0n1p3 LUKS_OPAL_TEST_PASSPHRASE=... \
+//	    go test -run TestOpalRealHardware -v .
+func TestOpalRealHardware(t *testing.T) {
+	dev := os.Getenv("LUKS_OPAL_TEST_DEVICE")
+	pass := os.Getenv("LUKS_OPAL_TEST_PASSPHRASE")
+	if dev == "" || pass == "" {
+		t.Skip("set LUKS_OPAL_TEST_DEVICE and LUKS_OPAL_TEST_PASSPHRASE to run against real OPAL hardware")
+	}
+
+	d, err := Open(dev)
+	require.NoError(t, err)
+	defer d.Close()
+
+	const name = "luksgo-opal-test"
+	require.NoError(t, d.UnlockAny([]byte(pass), name))
+	defer func() { require.NoError(t, Lock(name)) }()
+
+	// The dm device exists as soon as UnlockAny returns, but the
+	// /dev/mapper symlink is created asynchronously by udev.
+	path := "/dev/mapper/" + name
+	var m *os.File
+	for range 100 {
+		if m, err = os.Open(path); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NoError(t, err, "waiting for %s", path)
+	defer m.Close()
+
+	// the mapped device must expose readable plaintext
+	buf := make([]byte, 4096)
+	_, err = m.Read(buf)
+	require.NoError(t, err)
+}

--- a/testdata/metadata/hw_opal.json
+++ b/testdata/metadata/hw_opal.json
@@ -1,0 +1,56 @@
+{
+  "keyslots": {
+    "0": {
+      "type": "luks2",
+      "key_size": 32,
+      "af": {
+        "type": "luks1",
+        "stripes": 4000,
+        "hash": "sha256"
+      },
+      "area": {
+        "type": "raw",
+        "encryption": "aes-xts-plain64",
+        "key_size": 32,
+        "offset": "32768",
+        "size": "131072"
+      },
+      "kdf": {
+        "type": "argon2id",
+        "time": 4,
+        "memory": 235980,
+        "cpus": 2,
+        "salt": "z6vz4xK7cjan92rDA5JF8O6Jk2HouV0O8DMB6GlztVk="
+      }
+    }
+  },
+  "tokens": {},
+  "segments": {
+    "0": {
+      "type": "hw-opal",
+      "offset": "16777216",
+      "size": "1073741824",
+      "opal_segment_number": 3,
+      "opal_key_size": 32,
+      "opal_segment_size": "1073741824"
+    }
+  },
+  "digests": {
+    "0": {
+      "type": "pbkdf2",
+      "keyslots": ["0"],
+      "segments": ["0"],
+      "hash": "sha256",
+      "iterations": 110890,
+      "salt": "G8gqtKhS96IbogHyJLO+t9kmjLkx+DM3HHJqQtgc2Dk=",
+      "digest": "C9JWko5m+oYmjg6R0t/98cGGzLr/4UaG3hImSJMivfc="
+    }
+  },
+  "config": {
+    "json_size": "12288",
+    "keyslots_size": "4161536",
+    "requirements": {
+      "mandatory": ["opal"]
+    }
+  }
+}

--- a/testdata/metadata/hw_opal_crypt.json
+++ b/testdata/metadata/hw_opal_crypt.json
@@ -1,0 +1,59 @@
+{
+  "keyslots": {
+    "0": {
+      "type": "luks2",
+      "key_size": 96,
+      "af": {
+        "type": "luks1",
+        "stripes": 4000,
+        "hash": "sha256"
+      },
+      "area": {
+        "type": "raw",
+        "encryption": "aes-xts-plain64",
+        "key_size": 64,
+        "offset": "32768",
+        "size": "385024"
+      },
+      "kdf": {
+        "type": "argon2id",
+        "time": 4,
+        "memory": 235980,
+        "cpus": 2,
+        "salt": "z6vz4xK7cjan92rDA5JF8O6Jk2HouV0O8DMB6GlztVk="
+      }
+    }
+  },
+  "tokens": {},
+  "segments": {
+    "0": {
+      "type": "hw-opal-crypt",
+      "offset": "16777216",
+      "size": "1073741824",
+      "iv_tweak": "0",
+      "encryption": "aes-xts-plain64",
+      "sector_size": 512,
+      "opal_segment_number": 3,
+      "opal_key_size": 32,
+      "opal_segment_size": "1073741824"
+    }
+  },
+  "digests": {
+    "0": {
+      "type": "pbkdf2",
+      "keyslots": ["0"],
+      "segments": ["0"],
+      "hash": "sha256",
+      "iterations": 110890,
+      "salt": "G8gqtKhS96IbogHyJLO+t9kmjLkx+DM3HHJqQtgc2Dk=",
+      "digest": "C9JWko5m+oYmjg6R0t/98cGGzLr/4UaG3hImSJMivfc="
+    }
+  },
+  "config": {
+    "json_size": "12288",
+    "keyslots_size": "4161536",
+    "requirements": {
+      "mandatory": ["opal"]
+    }
+  }
+}

--- a/volume.go
+++ b/volume.go
@@ -7,6 +7,7 @@ import (
 	_ "crypto/sha256" // register crypto.SHA256
 	_ "crypto/sha512" // register crypto.SHA384 and crypto.SHA512
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/anatol/devmapper.go"
@@ -24,6 +25,15 @@ type Volume struct {
 	StorageSectorSize uint64
 	StorageOffset     uint64 // offset of underlying storage in bytes
 	StorageSize       uint64 // length of underlying device in bytes, zero means that size should be calculated using `diskSize` function
+
+	// TCG OPAL hardware-encryption segments (cryptsetup >= 2.7). For these,
+	// key holds the full digest-verified keyslot key: its first opalKeySize
+	// bytes are the OPAL locking-range passphrase, the remainder (empty for
+	// "hw-opal") is the dm-crypt volume key.
+	segmentType       string // "" or "crypt" (dm-crypt), "hw-opal", "hw-opal-crypt"
+	opalKeySize       uint64
+	opalSegmentNumber uint
+	opalSegmentSize   uint64 // locking-range length in bytes
 }
 
 // map of LUKS flag names to its dm-crypt counterparts
@@ -67,38 +77,189 @@ func (v *Volume) HMAC(h crypto.Hash, message []byte) ([]byte, error) {
 
 // SetupMapper creates a device mapper for the given LUKS volume
 func (v *Volume) SetupMapper(name string) error {
-	kernelFlags := make([]string, 0, len(v.Flags))
+	switch v.segmentType {
+	case "", "crypt": // "" covers LUKS1, which predates segment types
+		return v.setupCryptMapper(name)
+	case "hw-opal", "hw-opal-crypt":
+		return v.setupOpalMapper(name)
+	default:
+		return fmt.Errorf("unsupported segment type: %v", v.segmentType)
+	}
+}
+
+// dmUUID builds a UUID in the format expected by cryptsetup's
+// dm_prepare_uuid(): "CRYPT-<type>-<uuid_no_dashes>-<dm_name>"
+func (v *Volume) dmUUID(name string) string {
+	return fmt.Sprintf("CRYPT-%v-%v-%v", v.LuksType, strings.ReplaceAll(v.UUID, "-", ""), name)
+}
+
+// Clear wipes the volume key material. Call it once the volume is no longer
+// needed (after SetupMapper); the Unlock/UnlockAny helpers do this
+// automatically.
+func (v *Volume) Clear() {
+	clearSlice(v.key)
+}
+
+// kernelFlags translates the LUKS-named flags to their dm-crypt counterparts,
+// erroring on flags this library does not know.
+func (v *Volume) kernelFlags() ([]string, error) {
+	flags := make([]string, 0, len(v.Flags))
 	for _, f := range v.Flags {
 		flag, ok := flagsKernelNames[f]
 		if !ok {
-			return fmt.Errorf("unknown LUKS flag: %v", f)
+			return nil, fmt.Errorf("unknown LUKS flag: %v", f)
 		}
-		kernelFlags = append(kernelFlags, flag)
+		flags = append(flags, flag)
+	}
+	return flags, nil
+}
+
+// buildCryptTable assembles the dm-crypt table shared by the software and the
+// hw-opal-crypt activation paths; key is the dm-crypt volume key.
+func (v *Volume) buildCryptTable(key []byte) (*devmapper.CryptTable, error) {
+	kernelFlags, err := v.kernelFlags()
+	if err != nil {
+		return nil, err
 	}
 
 	// dm-crypt requires both size and offset to be aligned to the sector size
 	if v.StorageSize%v.StorageSectorSize != 0 {
-		return fmt.Errorf("storage size must be multiple of sector size")
+		return nil, fmt.Errorf("storage size must be multiple of sector size")
 	}
 	if v.StorageOffset%v.StorageSectorSize != 0 {
-		return fmt.Errorf("offset must be multiple of sector size")
+		return nil, fmt.Errorf("offset must be multiple of sector size")
 	}
 
-	table := devmapper.CryptTable{
+	return &devmapper.CryptTable{
 		Start:         0,
 		Length:        v.StorageSize,
 		BackendDevice: v.BackingDevice,
 		BackendOffset: v.StorageOffset,
 		Encryption:    v.StorageEncryption,
-		Key:           v.key,
+		Key:           key,
 		IVTweak:       v.StorageIvTweak,
 		Flags:         kernelFlags,
 		SectorSize:    v.StorageSectorSize,
+	}, nil
+}
+
+func (v *Volume) setupCryptMapper(name string) error {
+	table, err := v.buildCryptTable(v.key)
+	if err != nil {
+		return err
+	}
+	return devmapper.CreateAndLoad(name, v.dmUUID(name), 0, *table)
+}
+
+// setupOpalMapper activates a TCG OPAL hardware-encrypted segment: it unlocks
+// the drive's locking range with the OPAL prefix of the keyslot key, then maps
+// the now-readable range with dm-linear ("hw-opal") or dm-crypt on top of it
+// ("hw-opal-crypt").
+func (v *Volume) setupOpalMapper(name string) error {
+	if v.opalKeySize == 0 || v.opalKeySize > uint64(len(v.key)) {
+		return fmt.Errorf("invalid OPAL key size %d for a %d-byte volume key", v.opalKeySize, len(v.key))
+	}
+	opalKey := v.key[:v.opalKeySize]
+
+	// Validate header flags even where dm-linear later drops them: an
+	// unknown flag means a header this library does not fully understand.
+	if _, err := v.kernelFlags(); err != nil {
+		return err
 	}
 
-	// Build a UUID in the format expected by cryptsetup's dm_prepare_uuid():
-	// "CRYPT-<type>-<uuid_no_dashes>-<dm_name>"
-	uuid := fmt.Sprintf("CRYPT-%v-%v-%v", v.LuksType, strings.ReplaceAll(v.UUID, "-", ""), name)
+	// SED ioctls work on the partition fd; the kernel routes them to the
+	// controller. Read-only is sufficient for all of them.
+	f, err := os.Open(v.BackingDevice)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
 
-	return devmapper.CreateAndLoad(name, uuid, 0, table)
+	status, err := opalGetStatusIoctl(f)
+	if err != nil {
+		return err
+	}
+	const needed = opalFlSupported | opalFlLockingSupported
+	if status.Flags&needed != needed {
+		return fmt.Errorf("device %v does not support OPAL locking (status flags %#x)", v.BackingDevice, status.Flags)
+	}
+
+	// Before unlocking, verify that the locking range the drive reports
+	// matches the geometry the LUKS2 header promises: a divergence would
+	// expose the wrong ciphertext as if it were the volume. Only when the
+	// firmware genuinely cannot answer the queries (ENOTTY/EOPNOTSUPP) is
+	// the verification skipped; any other failure — notably NOT_AUTHORIZED —
+	// is fatal. When skipping, the range is conservatively treated as
+	// having been locked, so a later failure re-locks it; the flip side
+	// (re-locking a range that was already unlocked, possibly in use
+	// elsewhere) is accepted as the lesser risk.
+	wasLocked := true
+	geo, err := opalGetGeometryIoctl(f)
+	switch {
+	case err == nil:
+		lr, err := opalGetLrStatusIoctl(f, v.opalSegmentNumber, opalKey)
+		switch {
+		case err == nil:
+			partStart, err := partitionStartSector(f)
+			if err != nil {
+				return err
+			}
+			if err := verifyOpalGeometry(lr, geo.LogicalBlockSize, partStart, v.StorageOffset, v.opalSegmentSize); err != nil {
+				return err
+			}
+			wasLocked = lr.LState == opalLK
+		case isOpalQueryUnsupported(err):
+			// verification skipped, see above
+		default:
+			return err
+		}
+	case isOpalQueryUnsupported(err):
+		// verification skipped, see above
+	default:
+		return err
+	}
+
+	if err := opalUnlock(f, v.opalSegmentNumber, opalKey); err != nil {
+		return err
+	}
+	// A save failure only affects resume from S3 suspend (the range comes
+	// back locked); re-locking stays functional because relockOnError
+	// passes the key explicitly.
+	_ = opalSaveUnlockForResume(f, v.opalSegmentNumber, opalKey)
+
+	var table devmapper.Table
+	if v.segmentType == "hw-opal" {
+		// no software encryption: the unlocked range is plaintext
+		table = devmapper.LinearTable{
+			Start:         0,
+			Length:        v.StorageSize,
+			BackendDevice: v.BackingDevice,
+			BackendOffset: v.StorageOffset,
+		}
+	} else {
+		cryptTable, err := v.buildCryptTable(v.key[v.opalKeySize:])
+		if err != nil {
+			return v.relockOnError(f, wasLocked, opalKey, err)
+		}
+		table = *cryptTable
+	}
+
+	if err := devmapper.CreateAndLoad(name, v.dmUUID(name), 0, table); err != nil {
+		return v.relockOnError(f, wasLocked, opalKey, err)
+	}
+	return nil
+}
+
+// relockOnError restores the locked state after a post-unlock failure, but
+// only when the range was actually locked when we found it. The key is passed
+// explicitly so re-locking works even when the save step failed and the
+// kernel has no stored copy.
+func (v *Volume) relockOnError(f *os.File, wasLocked bool, opalKey []byte, err error) error {
+	if !wasLocked {
+		return err
+	}
+	if lockErr := opalLock(f, v.opalSegmentNumber, opalKey); lockErr != nil {
+		return fmt.Errorf("%w (additionally, re-locking the OPAL range failed: %v)", err, lockErr)
+	}
+	return err
 }


### PR DESCRIPTION
LUKS 2 now fully supports OPAL, both as a supplementary encryption method to dm-crypt, and a standalone one. If your hardware supports that - it's a nice way to have hardware backed transparent encryption with 0 performance cost (SED drives encrypt everything all the time, even when not "encrypted"). 

This is my attempt to add LUKS 2 OPAL support here so it can also be supported by booster. Note that this is **heavily LLM assisted work**.

The most notable change required for this to happen is replacing findCryptSegment with findStorageSegment and all the refactoring that goes into that. 

There are some slight issues here too:
1 - OPAL can not be tested on QEMU fully, only if you have an OPAL-capable SSD passed through via VFIO. That's because QEMU's NVMe drive can't emulate it. So the tests work around that fact to the best of my ability, but to truly fully cover this case a hardware setup is required. Personally, I've tested it in this exact scenario - on a QEMU machine with a real SSD passed through. This still leaves a small untested gap with S3 sleep that I'm committed to try and get to work if its broken.

2 - OPAL error messages are going to fall through silently if they happen (IOC_OPAL_SAVE/ENOTTY/EOPNOTSUPP). Can be ignored for now.